### PR TITLE
update project url to twisted

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ author = Twisted Matrix Laboratories
 author_email = twisted-python@twistedmatrix.com
 maintainer = Thomas Grainger
 maintainer_email = cython-test-exception-raiser@graingert.co.uk
-url = https://github.com/graingert/cython-test-exception-raiser
+url = https://github.com/twisted/cython-test-exception-raiser
 license = MIT
 classifiers =
     Programming Language :: Python :: 3


### PR DESCRIPTION
cython-test-exception-raiser was developed in my personal github account namespace, but it's been moved here