### PR TITLE
#12528 Add ABI3 wheels to support Python 3.14 and other future Python versions

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -85,10 +85,6 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
-    # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact-*
+          pattern: artifact-*
           merge-multiple: true
           path: dist
 

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -3,8 +3,13 @@ on:
   push:
     branches:
       - default
-    tags:
-      - v*
+    # To simplify the release process, the publishing is triggered on tag.
+    # We should make sure to only push tags for new releases.
+    # If we start using tags for non-release purposes,
+    # this needs to be updated.
+    #
+    # We need to explicitly configure an expression that matches anything.
+    tags: [ "**" ]
   pull_request:
 
 jobs:
@@ -13,25 +18,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.14'
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.1
+          python -m pip install cibuildwheel==3.2.1
 
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -39,9 +44,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -53,25 +58,31 @@ jobs:
       - name: Build sdist
         run: python -m build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: artifact-*
+          merge-multiple: true
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+      - name: Check files
+        run: ls -al dist/
+
+      - name: Publish to PyPI - on tag
+        # Skip upload to PyPI if we don't have a tag
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -28,13 +28,17 @@ jobs:
         with:
           python-version: '3.14'
 
-      - name: Install cibuildwheel
+      - name: Install deps
         run: |
-          python -m pip install cibuildwheel==3.2.1
+          python -m pip install cibuildwheel==3.2.1 abi3audit 0.0.22
 
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Audit ABI3 wheels
+        run: |
+          abi3audit -vsS wheelhouse/*abi3*.whl
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -37,12 +37,16 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
+      - name: Check files
+        run: ls -al wheelhouse/
+
       - name: Audit ABI3 wheels
         run: |
           abi3audit -vsS wheelhouse/*abi3*.whl
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-wheels
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -65,6 +69,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-sdist
           path: dist/*.tar.gz
 
   upload_pypi:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -17,6 +17,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
@@ -30,7 +31,7 @@ jobs:
 
       - name: Install deps
         run: |
-          python -m pip install cibuildwheel==3.2.1 abi3audit 0.0.22
+          python -m pip install cibuildwheel==3.2.1 abi3audit==0.0.22
 
       - name: Build wheels
         run: |

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -12,6 +12,13 @@ on:
     tags: [ "**" ]
   pull_request:
 
+
+defaults:
+  run:
+    # Use bash on Windows for consistency.
+    shell: bash
+
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -46,7 +53,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact-wheels
+          name: artifact-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+wheelhouse/
 downloads/
 eggs/
 .eggs/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-2025.10.0 (2025-10-29)
+2025.11.0 (2025-11-02)
 ----------------------
 
-- Enable wheels for Python 3.14.
+- Enable ABI3 binary wheels for generic Python support.
 
 
 1.0.2 (2021-08-10)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.0.3 (unreleased)
-------------------
 
-- Nothing changed yet.
+2025.10.0 (2025-10-29)
+----------------------
+
+- Enable wheels for Python 3.14.
 
 
 1.0.2 (2021-08-10)

--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,59 @@
+Introduction
+============
+
 A trivial extension that just raises an exception.
 See L{twisted.test.test_failure.test_failureConstructionWithMungedStackSucceeds}.
+
+Only used to help test twisted/twisted.
+
+Report issues at https://github.com/twisted/twisted/issues
+
+Dev process
+===========
+
+* We use `cibuildwheel` to generate the wheels.
+* You will need access to a Docker server.
+* You will need Python 3.11 or newer to run cibuildwheel.
+  This does not affect the generated wheels,
+  as they are build inside the container.
+* Use `python -m cibuildwheel --output-dir wheelhouse` to generate the wheels.
+  This is the same command use by GitHub Actions.
+  You can update the `pyproject.toml` file to adjust the cibuildwheel options.
+
+
+Release process
+===============
+
+
+Pre-release steps
+-----------------
+
+* Make sure that a ticket is created for twisted/twisted that covers
+  the new release and explain why we need the new release.
+* Create a new branch with a name that starts with the twisted/twisted
+  issue number. Ex: `12528-python-3.14-support`
+* Update the version inside setup.cfg. We now use calendar versioning.
+* Make the required code changes.
+* Create a pull request and make sure all checks pass.
+  The wheels are generated as part of the PR checks,
+  but they are not yet published to PyPI.
+* Request a review from `twisted-contributors`
+
+
+Release steps
+-------------
+
+* Use GitHub Release to create a new release together with a new tag.
+* You don't have to create a GitHub Release, the important part is to
+  create a new tag.
+* The tag value is the version. Without any prefix.
+* Once a tag is pushed to the repo, GitHub Action will re-run all the jobs
+  and will publish to PyPI.
+
+
+Post-release steps
+------------------
+
+* Update the version inside setup.cfg to the next development version.
+  Increment the micro version and add a .dev0 suffix.
+* Merge the pull request

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
+# We enable all builds and then cherry-pick the platforms via the `build`
+# configuration below.
 enable = ["all"]
 # See https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # Not sure why it was failing on PyPy 3.11.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,8 @@ requires = [
     "cython >= 0.29.21",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+enable = ["all"]
+# Not sure why it was failing on PyPy 3.11.
+build = "cp38-* pp310-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 enable = ["all"]
+# See https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # Not sure why it was failing on PyPy 3.11.
 build = "cp38-* pp310-*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cython-test-exception-raiser
-version = 25.10.0
+version = 25.11.0
 description = A trivial extension that just raises an exception.
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cython-test-exception-raiser
-version = 25.11.0
+version = 25.11.1.dev0
 description = A trivial extension that just raises an exception.
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cython-test-exception-raiser
-version = 1.0.3.dev0
+version = 25.10.0
 description = A trivial extension that just raises an exception.
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,15 +10,17 @@ maintainer = Thomas Grainger
 maintainer_email = cython-test-exception-raiser@graingert.co.uk
 url = https://github.com/twisted/cython-test-exception-raiser
 license = MIT
-python_requires = >=3.6
+python_requires = >=3.8
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
             py_limited_api=True
         ),
     ]),
-    #options={"bdist_wheel": {"py_limited_api": "cp38"}},
+    options={"bdist_wheel": {"py_limited_api": "cp38"}},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,23 @@
-from setuptools import setup
+from setuptools import Extension, setup
 from Cython.Build import cythonize
 
+# Py_LIMITED_API values:
+#
+# 0x03080000 - Python 3.8 - the minimum version that Cython supports.
+# 0x030B0000 - Python 3.11 - support typed memoryviews.
+# 0x030C0000 - Python 3.12 - support vectorcall (performance improvement).
 
-setup(ext_modules=cythonize("cython_test_exception_raiser/raiser.pyx"))
+setup(
+    ext_modules=cythonize([
+        Extension(
+            name="raiser",
+            sources=["cython_test_exception_raiser/raiser.pyx"],
+            define_macros=[
+                # For now we are at python 3.8 as we still support 3.10.
+                ("Py_LIMITED_API", 0x03080000),
+            ],
+            py_limited_api=True
+        ),
+    ]),
+    #options={"bdist_wheel": {"py_limited_api": "cp38"}},
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from setuptools import Extension, setup
 from Cython.Build import cythonize
 
+# ABI3 example from https://github.com/joerick/python-abi3-package-sample
+# Cython docs at
+# https://docs.cython.org/en/latest/src/userguide/limited_api.html
+#
 # Py_LIMITED_API values:
 #
 # 0x03080000 - Python 3.8 - the minimum version that Cython supports.


### PR DESCRIPTION
This is to help fix https://github.com/twisted/twisted/issues/12528

Instead of building separate wheels for Python 3.14, I went with abi3 wheels.

This should reduce the need to recreate wheels for each new Python version.

abi3audit is used to validate the files.

I don't know if PyPY has ABI3... so we still have separate wheels for PyPY 3.10

The wheels are build for Python 3.8 since this is the minimum ABI3 that covers Python 3.9 and 3.10.

Once we remove support for Python 3.10 we can move to the ABI from 3.11

For macOS we only have ARM64 wheels. I hope this is fine and nobody used Intel CPU with macOS for any serious business :)


I have renamed the default branch to "trunk" to match the other repos.

I have enabled branch protection for the default branch.

The list of files to be published can be reviewed here

https://github.com/twisted/cython-test-exception-raiser/actions/runs/18911800632/job/53984931607?pr=15#step:3:8