### PR TITLE
Build for limited API only on supported interpreters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+Unreleased
+----------
+
+- Enable thread-free wheels for Python 3.13 and 3.14.
+- Enable PYPY 3.11 wheels.
+
+
 2025.11.0 (2025-11-02)
 ----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ build-backend = "setuptools.build_meta"
 enable = ["all"]
 # See https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # Not sure why it was failing on PyPy 3.11.
-build = "cp38-* pp310-*"
+build = "cp38-* pp310-* cp313t-* cp314t-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,4 @@ build-backend = "setuptools.build_meta"
 # configuration below.
 enable = ["all"]
 # See https://cibuildwheel.pypa.io/en/stable/options/#build-skip
-# Not sure why it was failing on PyPy 3.11.
-build = "cp38-* pp310-* cp313t-* cp314t-*"
+build = "cp38-* pp310-* pp311-* cp313t-* cp314t-*"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+import sys
+import sysconfig
+
 from setuptools import Extension, setup
 from Cython.Build import cythonize
 
@@ -11,17 +14,27 @@ from Cython.Build import cythonize
 # 0x030B0000 - Python 3.11 - support typed memoryviews.
 # 0x030C0000 - Python 3.12 - support vectorcall (performance improvement).
 
+py_limited_api_kwargs = {}
+if sys.implementation.name == "cpython" and not sysconfig.get_config_var(
+    "Py_GIL_DISABLED"
+):
+    py_limited_api_kwargs = {
+        "define_macros": [
+            # For now we are at python 3.8 as we still support 3.10.
+            ("Py_LIMITED_API", 0x03080000),
+        ],
+        "py_limited_api": True,
+    }
+
 setup(
-    ext_modules=cythonize([
-        Extension(
-            name="raiser",
-            sources=["cython_test_exception_raiser/raiser.pyx"],
-            define_macros=[
-                # For now we are at python 3.8 as we still support 3.10.
-                ("Py_LIMITED_API", 0x03080000),
-            ],
-            py_limited_api=True
-        ),
-    ]),
+    ext_modules=cythonize(
+        [
+            Extension(
+                name="raiser",
+                sources=["cython_test_exception_raiser/raiser.pyx"],
+                **py_limited_api_kwargs
+            ),
+        ]
+    ),
     options={"bdist_wheel": {"py_limited_api": "cp38"}},
 )

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from Cython.Build import cythonize
 # 0x030C0000 - Python 3.12 - support vectorcall (performance improvement).
 
 py_limited_api_kwargs = {}
+bdist_wheel_kwargs = {}
 if sys.implementation.name == "cpython" and not sysconfig.get_config_var(
     "Py_GIL_DISABLED"
 ):
@@ -25,6 +26,7 @@ if sys.implementation.name == "cpython" and not sysconfig.get_config_var(
         ],
         "py_limited_api": True,
     }
+    bdist_wheel_kwargs = {"py_limited_api": "cp38"}
 
 setup(
     ext_modules=cythonize(
@@ -36,5 +38,5 @@ setup(
             ),
         ]
     ),
-    options={"bdist_wheel": {"py_limited_api": "cp38"}},
+    options={"bdist_wheel": {**bdist_wheel_kwargs}},
 )


### PR DESCRIPTION
Pass the limited API options only when building for non-free-threading CPython versions.  Passing the flags on other interpreters (such as PyPy or GraalPy) or free-threading CPython versions results in build failures due to the limited API not being supported.

While this package doesn't support free-threading Python right now, I think it makes sense to make the condition future-proof while I'm already fixing PyPy builds.

See also https://github.com/cython/cython/issues/7279