### PR TITLE
Fix `raiser` extension to be installed in the package

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ Changelog
 Unreleased
 ----------
 
-- Fix extension to be installed inside ``cython_test_exception_raiser``
+- The ``raiser`` method is now exposed inside the ``cython_test_exception_raiser`` package.
+  This was a regression introduced in 25.11.1 in #15.
   package again.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ Changelog
 Unreleased
 ----------
 
-- No changes yet.
+- Fix extension to be installed inside ``cython_test_exception_raiser``
+  package again.
 
 
 2025.11.1 (2025-11-06)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ext_modules=cythonize(
         [
             Extension(
-                name="raiser",
+                name="cython_test_exception_raiser.raiser",
                 sources=["cython_test_exception_raiser/raiser.pyx"],
                 **py_limited_api_kwargs
             ),


### PR DESCRIPTION
Fix the build system to build the `raiser` extension inside the `cython_test_exception_raiser` package rather than as a top-level extension.  This reduces site-packages pollution, and restores compatibility with 1.x releases.

Fixes twisted/twisted#12608